### PR TITLE
Pass pathname prop to DragWindowRegion and display formatted path

### DIFF
--- a/src/components/DragWindowRegion.tsx
+++ b/src/components/DragWindowRegion.tsx
@@ -6,12 +6,25 @@ import {
 import React from "react"
 import { SidebarTrigger } from "./ui/sidebar"
 
-export default function DragWindowRegion() {
+export default function DragWindowRegion({
+    pathname = "/",
+}: {
+    pathname?: string
+}) {
+    // Format the path for display
+    const formattedPath = React.useMemo(() => {
+        return pathname === "/"
+            ? "Dashboard"
+            : pathname.slice(1).charAt(0).toUpperCase() + pathname.slice(2)
+    }, [pathname])
+
     return (
         <div className="flex items-stretch justify-between p-2">
             <SidebarTrigger />
             <div className="draglayer w-full">
-                <div className="flex flex-1 p-2 text-xs whitespace-nowrap text-gray-400"></div>
+                <div className="flex flex-1 p-2 text-xs whitespace-nowrap text-gray-400">
+                    {formattedPath}
+                </div>
             </div>
             <WindowButtons />
         </div>

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -95,7 +95,7 @@ export default function BaseLayout({
                         </SidebarFooter>
                     </Sidebar>
                     <main className="flex h-screen max-h-screen flex-1 flex-col overflow-hidden">
-                        <DragWindowRegion />
+                        <DragWindowRegion pathname={pathname} />
                         <div className="scrollbar-thin container flex-1 overflow-y-auto py-6">
                             {children}
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The window header now displays the current page name, showing "Dashboard" for the home page and a formatted name for other pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->